### PR TITLE
Droidian cutie

### DIFF
--- a/droidian_cutie.yaml
+++ b/droidian_cutie.yaml
@@ -44,8 +44,6 @@ actions:
     chroot: true
     description: install packages for the phone variant
     packages:
-      - droidian-quirks-dummy-modemmanager
-      - droidian-quirks-dummy-ofono2mm
       - adaptation-hybris-api{{ $apilevel }}-phone
       - cutie-phone-full
 {{end}}


### PR DESCRIPTION
The NetworkManager on debian is build without ofono enabled. Mobile data in cutie works only if there is a gsm device in NetworkManager.